### PR TITLE
add support for boolean/bool

### DIFF
--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -83,6 +83,10 @@ impl<'j> net_bluejekyll::NativePrimitivesRs<'j> for NativePrimitivesRsImpl<'j> {
         parent.call_1dad(self.env, arg0)
     }
 
+    fn invert(&self, _this:NetBluejekyllNativePrimitives<'j>, arg0: bool) -> bool {
+        return !arg0
+    }
+
     fn unsupported(
         &self,
         _this: NetBluejekyllNativePrimitives<'j>,

--- a/integration_tests/src/net/bluejekyll/NativePrimitives.java
+++ b/integration_tests/src/net/bluejekyll/NativePrimitives.java
@@ -30,6 +30,8 @@ public class NativePrimitives extends ParentClass {
 
     public native int callDadNative(int arg1);
 
+    public native boolean invert(boolean arg);
+
     public native java.io.File unsupported(java.io.File file);
 
     public java.io.File unsupportedMethod(java.io.File file) {

--- a/integration_tests/src/net/bluejekyll/TestPrimitives.java
+++ b/integration_tests/src/net/bluejekyll/TestPrimitives.java
@@ -10,6 +10,7 @@ public class TestPrimitives {
         test_add_values_native();
         test_print_hello();
         test_call_dad();
+        test_invert();
         System.out.println("<<<< " + TestPrimitives.class.getName() + " tests succeeded");
     }
 
@@ -69,6 +70,13 @@ public class TestPrimitives {
 
         if (expected != got) {
             throw new RuntimeException("Expected " + expected + " got " + got);
+        }
+    }
+
+    static void test_invert() {
+        NativePrimitives obj = new NativePrimitives();
+        if (obj.invert(true)) {
+            throw new RuntimeException("Expected false");
         }
     }
 }

--- a/jaffi_support/src/lib.rs
+++ b/jaffi_support/src/lib.rs
@@ -299,6 +299,12 @@ macro_rules! from_java_value {
     };
 }
 
+impl<'j> FromJavaValue<'j, JavaBoolean> for bool {
+    fn from_jvalue(_env: JNIEnv<'j>, jvalue: JValue<'j>) -> Self {
+        jvalue.z().expect("wrong type conversion")
+    }    
+}
+
 from_java_value!(JavaByte, u8, b);
 from_java_value!(JavaChar, char, c);
 from_java_value!(JavaDouble, f64, d);
@@ -337,6 +343,7 @@ macro_rules! into_java_value {
     };
 }
 
+into_java_value!(JavaBoolean, bool);
 into_java_value!(JavaByte, u8);
 into_java_value!(JavaChar, char);
 into_java_value!(JavaDouble, f64);
@@ -352,6 +359,7 @@ macro_rules! java_primitive {
     };
 }
 
+java_primitive!(JavaBoolean);
 java_primitive!(JavaByte);
 java_primitive!(JavaChar);
 java_primitive!(JavaDouble);
@@ -375,6 +383,7 @@ macro_rules! null_object {
     };
 }
 
+null_object!(JavaBoolean);
 null_object!(JavaByte);
 null_object!(JavaChar);
 null_object!(JavaDouble);


### PR DESCRIPTION
Adds support for mapping java `booleans`. The only tricky part is that `z` already returns rust `bool`, but `JavaBoolean` is actually represented by `u8`, which makes is incompatible with `from_java_value!` macro.