### PR TITLE
Change `&(dyn Any + Send)` to `&dyn Any`.

### DIFF
--- a/jaffi_support/src/exceptions.rs
+++ b/jaffi_support/src/exceptions.rs
@@ -21,7 +21,7 @@ use jni::{
 
 use crate::NullObject;
 
-pub fn get_panic_message(message: &'_ (dyn Any + Send)) -> Cow<'_, str> {
+pub fn get_panic_message(message: &dyn Any) -> Cow<'_, str> {
     match message {
         _ if message.is::<&'static str>() => {
             let msg: &'static str = message.downcast_ref::<&str>().expect("failed to downcast");


### PR DESCRIPTION
This changes `&(dyn Any + Send)` to `&dyn Any`, because the `Send` trait is a useless restriction for references. (`&(dyn Any + Send)` implicitly converts to `&dyn Any`, but not the other way around.)

See https://github.com/rust-lang/rust/pull/110799